### PR TITLE
The installer is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Wurst-MCX2
+# The installer it's not working anymore


### PR DESCRIPTION
Hi, I'm using Wurst for testing different profiles, but we can't download it anymore because the installer is broken. It doesn't start, please check the build and the Gson library

Best regards, HAlex.

P.S. We can't open issues, So I needed to open a pull request